### PR TITLE
Sort wiki articles by actual title instead of filename

### DIFF
--- a/wiki/index.php
+++ b/wiki/index.php
@@ -7,14 +7,18 @@ include __DIR__."/../header.php";
 
 <p>here's the articles on our wiki:</p>
 <ul>
-	<?php foreach (glob("source/*.md") as $file) {
-		$article = basename($file, ".md"); 
-		$title = preg_match("/title: (.*)/i", file_get_contents($file), $matches) 
-			? $matches[1] : $article;
-	?>
+        <?php 
+              $article_to_title = [];
+              foreach (glob("source/*.md") as $file) {
+                $article = basename($file, ".md");
+		$title = preg_match("/title: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : $article;
+                $article_to_title[$article] = $title;
+              }
+              sort($article_to_title);
+        ?>
+	<?php foreach ($article_to_title as $article => $title)	{ ?>
 		<li><a href="/wiki/<?=$article?>.html"><?=$title?></a></li>
 	<?php } ?>
 </ul>
 
 <?php include __DIR__."/../footer.php";
-

--- a/wiki/index.php
+++ b/wiki/index.php
@@ -14,7 +14,7 @@ include __DIR__."/../header.php";
 		$title = preg_match("/title: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : $article;
                 $article_to_title[$article] = $title;
               }
-              sort($article_to_title);
+              asort($article_to_title);
         ?>
 	<?php foreach ($article_to_title as $article => $title)	{ ?>
 		<li><a href="/wiki/<?=$article?>.html"><?=$title?></a></li>


### PR DESCRIPTION
I saw that there was an article titled "terminal multiplexers - screen" and another titled "terminal multiplexers - tmux". Yet for some reason, they didn't appear next to each other in the index page. Then I realized that the index page wasn't sorted in any kind of order, except for that of the original filenames of the markdown files.

Since that is rather arbitrary and not useful, this PR attempts to sort the articles by their actual display titles.