### PR TITLE
Categorize the wiki

### DIFF
--- a/wiki/index.php
+++ b/wiki/index.php
@@ -8,17 +8,37 @@ include __DIR__."/../header.php";
 <p>here's the articles on our wiki:</p>
 <ul>
         <?php 
-              $article_to_title = [];
+              $category_to_articles = [];
               foreach (glob("source/*.md") as $file) {
                 $article = basename($file, ".md");
 		$title = preg_match("/title: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : $article;
-                $article_to_title[$article] = $title;
+		$category = preg_match("/category: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : 'default';
+		if (array_key_exists($category, $category_to_articles)) {
+			array_push($category_to_articles[$category], [$article, $title]);
+		} else {
+			$category_to_articles[$category] = [[$article, $title]];
+		}
+                ksort($category_to_articles);
               }
-              asort($article_to_title);
         ?>
-	<?php foreach ($article_to_title as $article => $title)	{ ?>
-		<li><a href="/wiki/<?=$article?>.html"><?=$title?></a></li>
-	<?php } ?>
+	<?php foreach ($category_to_articles as $category => $articles)	{ ?>
+		<li><?=$category?></li>
+			<ul>
+        <?php
+		$article_titles = [];
+		$article_names = [];
+		foreach ($articles as $article) {
+			array_push($article_names, $article[0]);
+                        array_push($article_titles, $article[1]);
+		}
+		$name_to_title = array_combine($article_names, $article_titles);
+                asort($name_to_title);
+		foreach ($name_to_title as $name => $title) { ?>
+                          <li><a href="/wiki/<?=$name?>.html"><?=$title?></a></li>
+	<?php   } ?>
+			</ul>
+
+        <?php } ?>
 </ul>
 
 <?php include __DIR__."/../footer.php";

--- a/wiki/source/2fa.md
+++ b/wiki/source/2fa.md
@@ -1,6 +1,7 @@
 ---
 title: USING Two-Factor Authentication (2FA) ON TILDE.CLUB
 author: deepend
+category: tilde.club
 ---
 
 # Using Two-Factor Authentication (2FA).

--- a/wiki/source/archive.org.md
+++ b/wiki/source/archive.org.md
@@ -1,5 +1,6 @@
 ---
 title: archive.org
+category: links
 ---
 
 archive.org has an archive of tilde.club at http://web.archive.org/web/*/http://tilde.club                                      

--- a/wiki/source/bashblog.md
+++ b/wiki/source/bashblog.md
@@ -1,6 +1,7 @@
 --- 
 title: bashblog 
 author: deepend / benharri
+category: software
 ---
 
 

--- a/wiki/source/chat.md
+++ b/wiki/source/chat.md
@@ -3,6 +3,7 @@ title: Socializing and chat
 author: 
   - emv
   - benharri
+category: tilde.club
 ---
 
 ## irc

--- a/wiki/source/cli-for-beginners.md
+++ b/wiki/source/cli-for-beginners.md
@@ -1,6 +1,7 @@
 ---
 title: command line for absolute beginners
 author: cmccabe
+category: tutorial
 ---
 
 So, you want to join a public-access shell community like tilde.club,

--- a/wiki/source/code-of-conduct.md
+++ b/wiki/source/code-of-conduct.md
@@ -1,6 +1,7 @@
 --- 
 title: code of conduct 
-author: benharri 
+author: benharri
+category: tilde.club
 ---
 
 > **tl;dr** learn by doing and helping. be excellent to each other. have fun!

--- a/wiki/source/donate.md
+++ b/wiki/source/donate.md
@@ -1,6 +1,7 @@
 ---
 title: donate to tilde.club
 author: deepend
+category: tilde.club
 ---
 
 ## Methods you can donate to tilde.club.

--- a/wiki/source/edit_index.md
+++ b/wiki/source/edit_index.md
@@ -1,6 +1,7 @@
 ---
 title: Editing your index.html file
 author: vielmetti
+category: tutorial
 ---
 
 Type: `nano` index.html to open your index.html file and begin editing

--- a/wiki/source/email.md
+++ b/wiki/source/email.md
@@ -1,6 +1,7 @@
 ---
 title: email
 author: benharri
+category: tutorial
 ---
 
 Your shiny, new tilde.club account comes with an email account. `alpine`  is a command-line email application to use it, as is `mutt`. Good old-fashioned `mail` works too, although it's a little cryptic.

--- a/wiki/source/error404.md
+++ b/wiki/source/error404.md
@@ -1,6 +1,7 @@
 ---
 title: custom 404
 author: deepend
+category: tutorial
 ---
 
 All users can now setup their own custom 404 error page.  Just add a file named 404.html in ~/public_html

--- a/wiki/source/faq.md
+++ b/wiki/source/faq.md
@@ -1,6 +1,7 @@
 ---
 title: faq
 author: ford
+category: tilde.club
 ---
 
       _______________________________________

--- a/wiki/source/finding_index.md
+++ b/wiki/source/finding_index.md
@@ -1,5 +1,6 @@
 ---
 title: finding your index.html
+category: tutorial
 ---
 
 There are some basic command line commands you'll want to Google and learn, but for this tutorial you only need a few:

--- a/wiki/source/git.md
+++ b/wiki/source/git.md
@@ -1,5 +1,6 @@
 ---
 title: how to use git
+category: tutorial
 ---
 
 `git` is a version control system. It's pretty confusing at first, but

--- a/wiki/source/gopher.md
+++ b/wiki/source/gopher.md
@@ -1,6 +1,7 @@
 ---
 title: gopher
 author: benharri
+category: tutorial
 ---
 
 tilde.club now serves gopher! we're using

--- a/wiki/source/json.md
+++ b/wiki/source/json.md
@@ -1,5 +1,6 @@
 ---
 title: JSON
+category: software
 ---
 
 JSON is the "Javascript Object Notation", basically a file format for

--- a/wiki/source/leafnode.md
+++ b/wiki/source/leafnode.md
@@ -1,5 +1,6 @@
 ---
 title: Leafnode
+category: links
 ---
 
 `leafnode` is a news client suitable for "leaf" nodes, that is nodes that have no downstream feeds.

--- a/wiki/source/netiquette.md
+++ b/wiki/source/netiquette.md
@@ -1,5 +1,6 @@
 ---
 title: tilde.club netiquette
+category: tilde.club
 ---
 
 ## Two phrases we use a lot

--- a/wiki/source/safe-scripting-the-tilde-way.md
+++ b/wiki/source/safe-scripting-the-tilde-way.md
@@ -1,6 +1,7 @@
 ---
 title: safe scripting the tilde way
 author: michaelcoyote
+category: tutorial
 ---
 
 Welcome to tilde.club. For many of you this may be your first multi-user host and for even more of you this may be your *first* host. Welcome to all of you.  

--- a/wiki/source/screen.md
+++ b/wiki/source/screen.md
@@ -1,5 +1,6 @@
 ---
 title: terminal multiplexers - screen
+category: software
 ---
 
 `screen` is a unix utility that lets you manage multiple shells from within a single window. You switch between them with a few keystrokes. When you disconnect it keeps the processes alive, and you can reconnect from another login.

--- a/wiki/source/security.md
+++ b/wiki/source/security.md
@@ -1,6 +1,7 @@
 ---
 title: Editing Basic UNIX Security the Tilde way
 author: michaelcoyote
+category: tutorial
 ---
 
 

--- a/wiki/source/slrn.md
+++ b/wiki/source/slrn.md
@@ -1,5 +1,6 @@
 ---
 title: slrn
+category: links
 ---
 
 ``slrn`` is a news reader for [Usenet](usenet-news.html).

--- a/wiki/source/ssh.md
+++ b/wiki/source/ssh.md
@@ -1,6 +1,7 @@
 ---
 author: benharri
 title: ssh
+category: tutorial
 ---
 
 

--- a/wiki/source/sshfs.md
+++ b/wiki/source/sshfs.md
@@ -1,6 +1,7 @@
 ---
 author: jeffbonhag
 title: SSHFS
+category: software
 ---
 
 On OS X:

--- a/wiki/source/time-zone.md
+++ b/wiki/source/time-zone.md
@@ -1,5 +1,6 @@
 ---
 title: time zones
+category: tutorial
 ---
 
 The timezone by default on the server is UTC.

--- a/wiki/source/tin.md
+++ b/wiki/source/tin.md
@@ -1,5 +1,6 @@
 ---
 title: tin
+category: software
 ---
 
 tin is a threaded NNTP and spool based [UseNet](usenet-news.html) newsreader for a variety of platforms.

--- a/wiki/source/tmux.md
+++ b/wiki/source/tmux.md
@@ -1,5 +1,6 @@
 ---
 title: terminal multiplexers - tmux
+category: software
 ---
 
 TMUX IS THE BEST. Here's a super basic primer.

--- a/wiki/source/tunnelblick.md
+++ b/wiki/source/tunnelblick.md
@@ -1,5 +1,6 @@
 ---
 title: Tunnelblick
+category: links
 ---
 
 `tunnelblick` is an application for your Mac that allows you to configure

--- a/wiki/source/usenet-news.md
+++ b/wiki/source/usenet-news.md
@@ -1,5 +1,6 @@
 ---
 title: usenet news
+category: tutorial
 ---
 
 ## this is out of date and the netnews server is down

--- a/wiki/source/vimrc.md
+++ b/wiki/source/vimrc.md
@@ -1,5 +1,6 @@
 ---
 title: .vimrc file
+category: tutorial
 ---
 
 The file `.vimrc` in your home directory has instructions for [[vim]]

--- a/wiki/source/vpn-gate.md
+++ b/wiki/source/vpn-gate.md
@@ -1,5 +1,6 @@
 ---
 title: VPN Gate
+category: links
 ---
 
 `VPN Gate` is a project from U Tsukuba in Japan that allows you to 

--- a/wiki/source/wiki.md
+++ b/wiki/source/wiki.md
@@ -1,6 +1,7 @@
 ---
 title: how to contribute to this wiki
 author: benharri
+category: tilde.club
 ---
 
 ## got a topic you want to write about?


### PR DESCRIPTION
This patch adds support for a new frontmatter string, `category:`to all wiki articles and also categorizes all the articles.

What the index page looks like after categorization:

<img width="939" alt="Screenshot 2020-04-12 22 19 59" src="https://user-images.githubusercontent.com/57832/79094413-480b4880-7d0c-11ea-8ac0-1d0561d50c37.png">
