### PR TITLE
Corrects link to gophermap README

### DIFF
--- a/wiki/source/gopher.md
+++ b/wiki/source/gopher.md
@@ -54,7 +54,7 @@ gophernicus also supports the following special types:
 ## additional resources
 
 see [gophernicus' gophermap
-documentation](https://github.com/gophernicus/gophernicus/blob/master/README.Gophermap)
+documentation](https://github.com/gophernicus/gophernicus/blob/master/README.gophermap)
 for more info on available item types and other special selectors.
 
 if you're completely new to gopher, check out the [gopher zone](https://gopher.zone)!


### PR DESCRIPTION
The link to README.gophermap needed to be changed. In a263037 of
gophernicus, the filename was changed from README.Gophermap to
README.gophermap. Our Wiki has to change accordingly.