### PR TITLE
Update vimrc.md to point to 'net Archive

### DIFF
--- a/wiki/source/vimrc.md
+++ b/wiki/source/vimrc.md
@@ -16,4 +16,4 @@ au BufRead,BufNewFile *.md set filetype=markdown
 ``
 
 For more suggestions in deep depth on how to set up your `.vimrc` please read
-[this tutorial from Doug Black](http://dougblack.io/words/a-good-vimrc.html).
+[this tutorial from Doug Black](https://web.archive.org/web/20161224112739/https://dougblack.io/words/a-good-vimrc.html). (The website's no longer up, it's on the 'net archive.


### PR DESCRIPTION
Changed the link to point to https://web.archive.org/web/20161224112739/https://dougblack.io/words/a-good-vimrc.html instead of https://dougblack.io/word/a-good-vimrc.html.

It seems the original website was lost to time.