### PR TITLE
Highlight code tags on wiki pages

### DIFF
--- a/wiki/wiki.tmpl
+++ b/wiki/wiki.tmpl
@@ -16,7 +16,8 @@
 		<title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
                 <link rel="stylesheet" href="../style.css">
 		<style type="text/css">
-code{white-space: pre-wrap;}
+code{background: rgba(255, 187, 85, 0.15);padding: 0.1em 0.2em;border-radius: 0.3em;white-space: pre-wrap;}
+pre code{background: none;}
 span.smallcaps{font-variant: small-caps;}
 span.underline{text-decoration: underline;}
 div.column{display: inline-block; vertical-align: top; width: 50%;}


### PR DESCRIPTION
This change puts a light orange tint onto the background of code tags to visually
distinguish them from other text. I hope this will reduce any ambiguity of
where code blocks begin and end.

I've tried to keep code-style similar to the surrounding code, and the style of the
code tag in-line with the design of the site, but I'm happy to change any of this if
wanted.

Thanks!

(Here's an example of how the code tags on the [tmux page](https://tilde.club/wiki/tmux.html) look with these changes)
![image](https://user-images.githubusercontent.com/1363175/95663799-fff1a500-0b39-11eb-8001-76559e06ba2e.png)
