### PR TITLE
Include blockquote styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -147,6 +147,11 @@ div.alert-success {
 	background-color: darkgreen;
 }
 
+blockquote {
+    border-left: 2px solid #fb5;
+    padding: 0.5em;
+}	
+
 /* Mobile */
 @media (max-width: 768px) {
 	td {


### PR DESCRIPTION
This is just a tiny PR to give the `<blockquote>` tag a tilde.club-styled border.

I've been using this on my [personal site](https://tilde.club/~j0hax/) and I hope it might be of benefit for everyone:

![blockquote](https://user-images.githubusercontent.com/3802620/153582315-06b7a332-1c25-4dcc-93f3-dac29c059f67.png)

