### PR TITLE
Change example email

### DIFF
--- a/wiki/source/email.md
+++ b/wiki/source/email.md
@@ -23,7 +23,7 @@ connection settings:
 - pop3.tilde.club port 995 with ssl
 - smtp.tilde.club port 587 with starttls
 
-please remember to use only your tilde username as the login name, excluding the `@tilde.club`; for example `kot` instead of `kot@tilde.club`
+please remember to use only your tilde username as the login name, excluding the `@tilde.club`; for example `invalid` instead of `invalid@tilde.club`
 
 if you'd like your @tilde.club mail forwarded elsewhere, you can put an email 
 address in a file called `~/.forward`


### PR DESCRIPTION
I was getting a ton of spam at this address, probably wasn't a great idea to use my address here...
Replaced with `invalid@tilde.club` instead, which currently isn't taken. If there's a better address that's routed to nothing, we should use that instead.