### PR TITLE
Include subtle background for blockquote

### DIFF
--- a/style.css
+++ b/style.css
@@ -149,6 +149,7 @@ div.alert-success {
 
 blockquote {
     border-left: 2px solid #fb5;
+    background-color: rgba(255, 187, 85, 5%);
     padding: 0.5em;
 }	
 


### PR DESCRIPTION
Aesthetic tweak to the `<blockquote>` tag, which adds a 5% amber background.

Examples:

![Screenshot 2023-01-09 at 15-19-50 j0hax@tilde club](https://user-images.githubusercontent.com/3802620/211329445-37660cad-88d8-4221-824d-b628c2f85acc.png)

![Screenshot 2023-01-09 at 15-08-03 j0hax@tilde club](https://user-images.githubusercontent.com/3802620/211328701-5d0adfeb-1217-4d2e-b043-7448e4e7c133.png)
