### PR TITLE
Update irc.md

### DIFF
--- a/wiki/source/irc.md
+++ b/wiki/source/irc.md
@@ -17,7 +17,7 @@ server. try launching [tmux](tmux.html), [byobu](https://superuser.com/a/423397)
  or [screen](screen.html) to keep your chat session running.
 
 other clients like irssi are available as well! just connect to localhost on
-port 6667 and `/join #club`.
+port 6667 and `/join #club`. If your client defaults to enabling TLS, you'll need to specify that it shouldn't use TLS.
 
 feel free to use Newnet's [webchat](https://web.newnet.net/?join=club) if
 you prefer.

--- a/wiki/source/tin.md
+++ b/wiki/source/tin.md
@@ -7,6 +7,6 @@ tin is a threaded NNTP and spool based [UseNet](usenet-news.html) newsreader for
 
 [http://www.tin.org/](http://www.tin.org/)
 
-it's under active development, with a last release on October 3, 2014. It is installed on ``tilde.club``, and should be invoked as `tin -r` to read from the remote news spool. Use <tab> to go to the next unread article and `w` to write a new article.
+it's under active development, with a last release on December 24, 2023. It is installed on ``tilde.club``, and should be invoked as `tin -r` to read from the remote news spool. Use <tab> to go to the next unread article and `w` to write a new article.
 
 if you have `tin` on your local box and can do [[ssh port forwarding]], you can read news using it. (details forthcoming).


### PR DESCRIPTION
add extra info about localhost IRC connections

My weechat client (running on tilde.club) lost its connection to newnet/#club. It took me a few tries to get it reconnected.

What I learned:

- weechat defaults to using TLS when you add a new server
- therefore you must specify `-notls` when adding a localhost connection

Later on that evening:

While idly browsing the Wiki, I found myself on the page about `tin` and noticed the indicated last release date. Clicked over to the `tin` website and saw that the most recent release date was approximately "now". Updated the file to match!