### PR TITLE
Update last release date of `tin`

### DIFF
--- a/wiki/source/tin.md
+++ b/wiki/source/tin.md
@@ -7,6 +7,6 @@ tin is a threaded NNTP and spool based [UseNet](usenet-news.html) newsreader for
 
 [http://www.tin.org/](http://www.tin.org/)
 
-it's under active development, with a last release on December 24, 2023. It is installed on ``tilde.club``, and should be invoked as `tin -r` to read from the remote news spool. Use <tab> to go to the next unread article and `w` to write a new article.
+it's under active development, with a last release on December 24, 2024. It is installed on ``tilde.club``, and should be invoked as `tin -r` to read from the remote news spool. Use <tab> to go to the next unread article and `w` to write a new article.
 
 if you have `tin` on your local box and can do [[ssh port forwarding]], you can read news using it. (details forthcoming).

--- a/wiki/source/tin.md
+++ b/wiki/source/tin.md
@@ -7,6 +7,6 @@ tin is a threaded NNTP and spool based [UseNet](usenet-news.html) newsreader for
 
 [http://www.tin.org/](http://www.tin.org/)
 
-it's under active development, with a last release on December 24, 2024. It is installed on ``tilde.club``, and should be invoked as `tin -r` to read from the remote news spool. Use <tab> to go to the next unread article and `w` to write a new article.
+it is an actively maintained project, and is installed on ``tilde.club``. `tin` should be invoked as `tin -r` to read from the remote news spool. Use <tab> to go to the next unread article and `w` to write a new article.
 
 if you have `tin` on your local box and can do [[ssh port forwarding]], you can read news using it. (details forthcoming).


### PR DESCRIPTION
The latest release of `tin` is TIN 2.6.4 - which has been released on 24th of December, 2024.