### PR TITLE
Add order to wiki categories

### DIFF
--- a/header.php
+++ b/header.php
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?=isset($title) ? $title : "Welcome to ~tilde.club~"?></title>
-	<link rel="icon" type="image/png" href="favicon.png">
+	<link rel="icon" type="image/png" href="https://tilde.club/favicon.png">
     
     <!-- Preload CSS and image resources -->
     <link rel="preload" href="/style.css" as="style">

--- a/wiki/index.php
+++ b/wiki/index.php
@@ -19,6 +19,7 @@ include __DIR__."/../header.php";
 			{
                 $article = basename($file, ".md");
 				$title = preg_match("/title: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : $article;
+				$title = ucfirst($title);
 				$category = preg_match("/category: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : 'default';
 
 				if (array_key_exists($category, $category_to_articles)) 

--- a/wiki/index.php
+++ b/wiki/index.php
@@ -2,50 +2,58 @@
 $title = "tilde.club wiki";
 include __DIR__."/../header.php";
 ?>
-
 <h1 id="fancyboi">the tilde.club wiki</h1>
-
 	<div class="grid">
 		<div class="row">
-
 			<div class="col">
-
-<p>here's the articles on our wiki:</p>
-<ul>
-        <?php 
-              $category_to_articles = [];
-              foreach (glob("source/*.md") as $file) {
-                $article = basename($file, ".md");
-		$title = preg_match("/title: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : $article;
-		$category = preg_match("/category: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : 'default';
-		if (array_key_exists($category, $category_to_articles)) {
-			array_push($category_to_articles[$category], [$article, $title]);
-		} else {
-			$category_to_articles[$category] = [[$article, $title]];
-		}
-                ksort($category_to_articles);
-              }
-        ?>
-	<?php foreach ($category_to_articles as $category => $articles)	{ ?>
-		<li><?=$category?></li>
+			<p>Here's the articles on our wiki:</p>
 			<ul>
-        <?php
-		$article_titles = [];
-		$article_names = [];
-		foreach ($articles as $article) {
-			array_push($article_names, $article[0]);
-                        array_push($article_titles, $article[1]);
-		}
-		$name_to_title = array_combine($article_names, $article_titles);
-                asort($name_to_title);
-		foreach ($name_to_title as $name => $title) { ?>
-                          <li><a href="/wiki/<?=$name?>.html"><?=$title?></a></li>
-	<?php   } ?>
-			</ul>
+			<?php 
+			// category order
+			$order = ['tilde.club', 'tutorials', 'software', 'links'];
 
-        <?php } ?>
-</ul>
+            $category_to_articles = [];
+
+			// get articles
+			foreach (glob("source/*.md") as $file) 
+			{
+                $article = basename($file, ".md");
+				$title = preg_match("/title: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : $article;
+				$category = preg_match("/category: (.*)/i", file_get_contents($file), $matches) ? $matches[1] : 'default';
+
+				if (array_key_exists($category, $category_to_articles)) 
+					array_push($category_to_articles[$category], [$article, $title]);
+				else 
+					$category_to_articles[$category] = [[$article, $title]];
+				
+                ksort($category_to_articles);
+			}
+
+			foreach ($order as $category) 
+			{
+				echo '<li>'.ucwords($category).'</li>';
+				echo '<ul>';
+        
+				$article_titles = [];
+				$article_names = [];
+				
+				foreach ($category_to_articles[$category] as $article) 
+				{
+					array_push($article_names, $article[0]);
+					array_push($article_titles, $article[1]);
+				}
+
+				$name_to_title = array_combine($article_names, $article_titles);
+                asort($name_to_title);
+				
+				foreach ($name_to_title as $name => $title) 
+					echo '<li><a href="/wiki/'.$name.'.html">'.$title.'</a></li>';
+		
+				echo '</ul><br>';
+
+			} 
+			?>
+		</ul>
 	</div>
 </div>
-
-<?php include "../footer.php"; ?>
+<?php include "../footer.php"; 

--- a/wiki/source/2fa.md
+++ b/wiki/source/2fa.md
@@ -1,5 +1,5 @@
 ---
-title: USING Two-Factor Authentication (2FA) ON TILDE.CLUB
+title: Using Two-Factor Authentication (2FA) on Tilde.club
 author: deepend
 category: tutorials
 ---

--- a/wiki/source/bashblog.md
+++ b/wiki/source/bashblog.md
@@ -1,5 +1,5 @@
 --- 
-title: bashblog 
+title: bashblog (blog platform)
 author: 
   - deepend 
   - benharri

--- a/wiki/source/bbj.md
+++ b/wiki/source/bbj.md
@@ -1,6 +1,6 @@
 ---
-title: bbj
+title: BBJ (Bulletin Butter & Jelly)
 author: audiodude
-category: tutorials
+category: software
 ---
 bbj: bulletin butter and jelly, a cozy bbs in your terminal

--- a/wiki/source/cgi.md
+++ b/wiki/source/cgi.md
@@ -1,5 +1,5 @@
 ---
-title: "CGI: Making web applications like it's 90s"
+title: CGI: Making web applications like it's 90s
 category: tutorials
 author: xwindows
 ---

--- a/wiki/source/error404.md
+++ b/wiki/source/error404.md
@@ -1,5 +1,5 @@
 ---
-title: custom 404
+title: custom 404 error page
 author: deepend
 category: tutorials
 ---

--- a/wiki/source/multiplexers.md
+++ b/wiki/source/multiplexers.md
@@ -1,5 +1,5 @@
 ---
-title: Byobu, TMUX & Screen (Terminal Multiplexers)
+title: Byobu, TMUX & Screen (terminal multiplexers)
 author: rudi
 category: software
 ---

--- a/wiki/source/multiplexers.md
+++ b/wiki/source/multiplexers.md
@@ -1,5 +1,5 @@
 ---
-title: Terminal Multiplexers
+title: Byobu, TMUX & Screen (Terminal Multiplexers)
 author: rudi
 category: software
 ---

--- a/wiki/source/ssh.md
+++ b/wiki/source/ssh.md
@@ -1,7 +1,7 @@
 ---
 author: benharri
-title: SSH (secure shell)
-category: software
+title: How to connect using SSH (secure shell)
+category: tutorials
 ---
 
 

--- a/wiki/source/ssh.md
+++ b/wiki/source/ssh.md
@@ -1,7 +1,7 @@
 ---
 author: benharri
-title: ssh
-category: tutorials
+title: SSH (secure shell)
+category: software
 ---
 
 

--- a/wiki/source/sshfs.md
+++ b/wiki/source/sshfs.md
@@ -1,6 +1,6 @@
 ---
 author: jeffbonhag
-title: SSHFS
+title: SSHFS (SSH Filesystem)
 category: software
 ---
 

--- a/wiki/source/tin.md
+++ b/wiki/source/tin.md
@@ -1,5 +1,5 @@
 ---
-title: tin
+title: tin (UseNet reader)
 category: software
 ---
 

--- a/wiki/source/ttbp.md
+++ b/wiki/source/ttbp.md
@@ -1,7 +1,6 @@
 ---
-title: ttbp (feels)
-author:
-  - benharri
+title: ttbp / feels (blog platform)
+author: benharri
 category: software
 ---
 

--- a/wiki/source/vimrc.md
+++ b/wiki/source/vimrc.md
@@ -1,6 +1,6 @@
 ---
-title: .vimrc file
-category: tutorials
+title: Vim (editor) .vimrc file
+category: software
 ---
 
 The file `.vimrc` in your home directory has instructions for [[vim]]

--- a/wiki/source/vpnwhy.md
+++ b/wiki/source/vpnwhy.md
@@ -1,7 +1,7 @@
 ---
 title: Don't use VPN services
 author: joepie91 on github
-category: tilde.club
+category: tutorials
 ---
 
 # Don't use VPN services.

--- a/wiki/wiki.tmpl
+++ b/wiki/wiki.tmpl
@@ -14,7 +14,8 @@
 		<meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$" />
 		$endif$
 		<title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
-                <link rel="stylesheet" href="../style.css">
+        <link rel="stylesheet" href="https://tilde.club/style.css">
+		<link rel="icon" type="image/png" href="https://tilde.club/favicon.png">
 		<style type="text/css">
 code{background: rgba(255, 187, 85, 0.15);padding: 0.1em 0.2em;border-radius: 0.3em;white-space: pre-wrap;}
 pre code{background: none;}


### PR DESCRIPTION
Introduces a simple order for the wiki categories. Currently the wiki starts with "links" which is arguably the least important category, by adding an order the "tilde.club" category can be placed first, followed by "tutorials".